### PR TITLE
Adding Blocking Pool 

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,5 +1,4 @@
 [ ] - Add a `sort.Slice(execs, func(i, j int) bool ` on all list result in the database memory implementation
-[ ] - Scale is faulty
 [ ] - Check close
 [ ] - Configure logs
 [ ] - More tests

--- a/database.go
+++ b/database.go
@@ -1011,6 +1011,9 @@ type Database interface {
 	UpdateWorkflowEntity(entity *WorkflowEntity) error
 	GetWorkflowEntityProperties(id WorkflowEntityID, getters ...WorkflowEntityPropertyGetter) error
 	SetWorkflowEntityProperties(id WorkflowEntityID, setters ...WorkflowEntityPropertySetter) error
+	// specific
+	CountWorkflowEntityByQueue(queueID QueueID) (int, error)
+	CountWorkflowEntityByQueueByStatus(queueID QueueID, status EntityStatus) (int, error)
 
 	// Workflow Data
 	AddWorkflowData(entityID WorkflowEntityID, data *WorkflowData) (WorkflowDataID, error)
@@ -1032,6 +1035,9 @@ type Database interface {
 	GetWorkflowExecutionLatestByEntityID(entityID WorkflowEntityID) (*WorkflowExecution, error)
 	GetWorkflowExecutionProperties(id WorkflowExecutionID, getters ...WorkflowExecutionPropertyGetter) error
 	SetWorkflowExecutionProperties(id WorkflowExecutionID, setters ...WorkflowExecutionPropertySetter) error
+	// specific
+	CountWorkflowExecutionByQueue(queueID QueueID) (int, error)
+	CountWorkflowExecutionByQueueByStatus(queueID QueueID, status ExecutionStatus) (int, error)
 
 	// Workflow Execution Data
 	AddWorkflowExecutionData(executionID WorkflowExecutionID, data *WorkflowExecutionData) (WorkflowExecutionDataID, error)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 )
 
 require (
-	github.com/davidroman0O/retrypool v0.0.0-20241228214942-849e0ee393a6
+	github.com/davidroman0O/retrypool v0.0.0-20241229061510-f24ce71d3c9c
 	github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5
 	go.uber.org/automaxprocs v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 )
 
 require (
-	github.com/davidroman0O/retrypool v0.0.0-20241214064430-a855b1ead19c
+	github.com/davidroman0O/retrypool v0.0.0-20241228214942-849e0ee393a6
 	github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5
 	go.uber.org/automaxprocs v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davidroman0O/retrypool v0.0.0-20241228214942-849e0ee393a6 h1:V0ruRteXLyp/I8BDoiuikArJpkJNWCtFPT06hUH3tDM=
-github.com/davidroman0O/retrypool v0.0.0-20241228214942-849e0ee393a6/go.mod h1:Bs5wRV2c1mk6DXCd3Hc3mDWjX/BOt0LgbaxQYNSy3co=
+github.com/davidroman0O/retrypool v0.0.0-20241229061510-f24ce71d3c9c h1:yMJdJ2Tl+2Wfp3ajakV2tsz3+vA5O1qaV35GB4Th1dM=
+github.com/davidroman0O/retrypool v0.0.0-20241229061510-f24ce71d3c9c/go.mod h1:Bs5wRV2c1mk6DXCd3Hc3mDWjX/BOt0LgbaxQYNSy3co=
 github.com/k0kubun/pp/v3 v3.3.0 h1:/Unrck5tDGUSjsUJsmx9GUL64pNKOY5UEdoP1F7FBq8=
 github.com/k0kubun/pp/v3 v3.3.0/go.mod h1:wJadGBvcY6JKaiUkB89VzUACKDmTX1r4aQTPERpZc6w=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davidroman0O/retrypool v0.0.0-20241214064430-a855b1ead19c h1:t4jhm96MWC86/XGQs4JYquLo4xSond1ShDmfVYiBtC8=
-github.com/davidroman0O/retrypool v0.0.0-20241214064430-a855b1ead19c/go.mod h1:Bs5wRV2c1mk6DXCd3Hc3mDWjX/BOt0LgbaxQYNSy3co=
+github.com/davidroman0O/retrypool v0.0.0-20241228214942-849e0ee393a6 h1:V0ruRteXLyp/I8BDoiuikArJpkJNWCtFPT06hUH3tDM=
+github.com/davidroman0O/retrypool v0.0.0-20241228214942-849e0ee393a6/go.mod h1:Bs5wRV2c1mk6DXCd3Hc3mDWjX/BOt0LgbaxQYNSy3co=
 github.com/k0kubun/pp/v3 v3.3.0 h1:/Unrck5tDGUSjsUJsmx9GUL64pNKOY5UEdoP1F7FBq8=
 github.com/k0kubun/pp/v3 v3.3.0/go.mod h1:wJadGBvcY6JKaiUkB89VzUACKDmTX1r4aQTPERpZc6w=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/runtime.go
+++ b/runtime.go
@@ -243,10 +243,10 @@ type Future interface {
 }
 
 // CrossQueue is an external feature requesting an external intervention to trigger a workflow on another mechanism
-type crossQueueWorkflowHandler func(queueName string, workflowID WorkflowEntityID, workflowFunc interface{}, options *WorkflowOptions, args ...interface{}) Future
+type crossQueueWorkflowHandler func(queueName string, workflowID WorkflowEntityID, runID RunID, workflowFunc interface{}, options *WorkflowOptions, args ...interface{}) Future
 
 // CrossQueue is an external feature requesting for external operations to continue a workflow
-type crossQueueContinueAsNewHandler func(queueName string, workflowID WorkflowEntityID, workflowFunc interface{}, options *WorkflowOptions, args ...interface{}) Future
+type crossQueueContinueAsNewHandler func(queueName string, workflowID WorkflowEntityID, runID RunID, workflowFunc interface{}, options *WorkflowOptions, args ...interface{}) Future
 
 // Signal is an external feature requesting to store a signal outside for a published event
 type workflowNewSignalHandler func(workflowID WorkflowEntityID, workflowExecutionID WorkflowExecutionID, signalEntityID SignalEntityID, signalExecutionID SignalExecutionID, signal string, future Future) error
@@ -2675,6 +2675,7 @@ func (wi *WorkflowInstance) onCompleted(_ context.Context, args ...interface{}) 
 			_ = wi.onContinueAsNew( // Just start it running
 				queue,
 				workflowEntity.ID,
+				workflowEntity.RunID,
 				handler.Handler,
 				workflowOutput.ContinueAsNewOptions,
 				workflowOutput.ContinueAsNewArgs...,
@@ -4649,7 +4650,7 @@ func (ctx WorkflowContext) Workflow(stepID string, workflowFunc interface{}, opt
 			}
 
 			// then you're in charge on how you want the rest to happen
-			return ctx.onCrossQueueWorkflow(options.Queue, workflowEntity.ID, workflowFunc, options, args...)
+			return ctx.onCrossQueueWorkflow(options.Queue, workflowEntity.ID, workflowEntity.RunID, workflowFunc, options, args...)
 		}
 		// If no handler is set, return an error
 		future := NewRuntimeFuture()

--- a/tempolite.go
+++ b/tempolite.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
-	"sync/atomic"
 	"time"
 
 	"github.com/davidroman0O/retrypool"
@@ -45,7 +44,8 @@ type QueueInstance struct {
 	name  string
 	count int32
 
-	orchestrators *retrypool.Pool[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]]
+	// We use a blocking pool because the orchestrator will lock workers of the pool, we will have one Run as group per pool
+	orchestrators *retrypool.BlockingPool[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID], RunID, WorkflowEntityID]
 
 	workerMu          deadlock.RWMutex
 	processingWorkers map[WorkflowEntityID]*QueueWorker
@@ -140,7 +140,7 @@ func NewQueueInstance(ctx context.Context, db Database, registry *Registry, name
 		}
 	}
 
-	workers := []retrypool.Worker[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]]{}
+	workers := []retrypool.Worker[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]]{}
 	for i := 0; i < count; i++ {
 		workers = append(workers, NewQueueWorker(q))
 	}
@@ -148,60 +148,71 @@ func NewQueueInstance(ctx context.Context, db Database, registry *Registry, name
 	logger := retrypool.NewLogger(slog.LevelDebug)
 	logger.Enable()
 
-	q.orchestrators = retrypool.New(
+	q.orchestrators, err = retrypool.NewBlockingPool[
+		*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID], RunID, WorkflowEntityID](
 		ctx,
-		workers,
-		retrypool.WithLogger[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]](
-			logger,
-		),
-		retrypool.WithAttempts[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]](1),
-		retrypool.WithOnPanic[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]](
-			func(recovery interface{}, stackTrace string) {
-				fmt.Println("PANIC", recovery, stackTrace)
-			},
-		),
-		retrypool.WithRoundRobinDistribution[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]](),
-		retrypool.WithOnWorkerPanic[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]](
-			func(workerID int, recovery interface{}, stackTrace string) {
-				fmt.Println("WORKER PANIC", workerID, recovery, stackTrace)
-			},
-		),
-		// retrypool.WithDelay[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]](time.Second/2),
-		retrypool.WithOnDeadTask[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]](
-			func(deadTaskIndex int) {
-				fmt.Println("DEADTASK", deadTaskIndex)
-				// deadTask, err := q.orchestrators.GetDeadTask(deadTaskIndex)
-				// if err != nil {
-				// 	// too bad
-				// 	log.Printf("failed to get dead task: %v", err)
-				// 	return
-				// }
-				// errs := errors.New("failed to process request")
-				// for _, e := range deadTask.Errors {
-				// 	errs = errors.Join(errs, e)
-				// }
-				// deadTask.Data.CompleteWithError(errs)
-				// _, err = q.orchestrators.PullDeadTask(deadTaskIndex)
-				// if err != nil {
-				// 	// too bad
-				// 	log.Printf("failed to pull dead task: %v", err)
-				// }
-			},
-		),
-		// retrypool.WithOnNewDeadTask[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]](
-		// 	func(task *retrypool.DeadTask[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]], idx int) {
-		// 		errs := errors.New("failed to process request")
-		// 		for _, e := range task.Errors {
-		// 			errs = errors.Join(errs, e)
-		// 		}
-		// 		task.Data.CompleteWithError(errs)
-		// 		_, err := q.orchestrators.PullDeadTask(idx)
-		// 		if err != nil {
-		// 			// too bad
-		// 			log.Printf("failed to pull dead task: %v", err)
-		// 		}
-		// 	}),
+		retrypool.WithBlockingWorkerFactory(func() retrypool.Worker[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]] {
+			return NewQueueWorker(q)
+		}),
 	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create orchestrator: %w", err)
+	}
+
+	// q.orchestrators = retrypool.New(
+	// 	ctx,
+	// 	workers,
+	// 	retrypool.WithLogger[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]](
+	// 		logger,
+	// 	),
+	// 	retrypool.WithAttempts[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]](1),
+	// 	retrypool.WithOnPanic[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]](
+	// 		func(recovery interface{}, stackTrace string) {
+	// 			fmt.Println("PANIC", recovery, stackTrace)
+	// 		},
+	// 	),
+	// 	retrypool.WithRoundRobinDistribution[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]](),
+	// 	retrypool.WithOnWorkerPanic[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]](
+	// 		func(workerID int, recovery interface{}, stackTrace string) {
+	// 			fmt.Println("WORKER PANIC", workerID, recovery, stackTrace)
+	// 		},
+	// 	),
+	// 	// retrypool.WithDelay[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]](time.Second/2),
+	// 	retrypool.WithOnDeadTask[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]](
+	// 		func(deadTaskIndex int) {
+	// 			fmt.Println("DEADTASK", deadTaskIndex)
+	// 			// deadTask, err := q.orchestrators.GetDeadTask(deadTaskIndex)
+	// 			// if err != nil {
+	// 			// 	// too bad
+	// 			// 	log.Printf("failed to get dead task: %v", err)
+	// 			// 	return
+	// 			// }
+	// 			// errs := errors.New("failed to process request")
+	// 			// for _, e := range deadTask.Errors {
+	// 			// 	errs = errors.Join(errs, e)
+	// 			// }
+	// 			// deadTask.Data.CompleteWithError(errs)
+	// 			// _, err = q.orchestrators.PullDeadTask(deadTaskIndex)
+	// 			// if err != nil {
+	// 			// 	// too bad
+	// 			// 	log.Printf("failed to pull dead task: %v", err)
+	// 			// }
+	// 		},
+	// 	),
+	// 	// retrypool.WithOnNewDeadTask[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]](
+	// 	// 	func(task *retrypool.DeadTask[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]], idx int) {
+	// 	// 		errs := errors.New("failed to process request")
+	// 	// 		for _, e := range task.Errors {
+	// 	// 			errs = errors.Join(errs, e)
+	// 	// 		}
+	// 	// 		task.Data.CompleteWithError(errs)
+	// 	// 		_, err := q.orchestrators.PullDeadTask(idx)
+	// 	// 		if err != nil {
+	// 	// 			// too bad
+	// 	// 			log.Printf("failed to pull dead task: %v", err)
+	// 	// 		}
+	// 	// 	}),
+	// )
 
 	return q, nil
 }
@@ -217,39 +228,37 @@ func (qi *QueueInstance) Close() error {
 
 func (qi *QueueInstance) Wait() error {
 	return qi.orchestrators.WaitWithCallback(qi.ctx, func(queueSize, processingCount, deadTaskCount int) bool {
-		workersIDS, err := qi.orchestrators.Workers()
-		if err != nil {
-			logger.Error(qi.ctx, "failed to get workers", "error", err)
-			return false
-		}
+		// workersIDS, err := qi.orchestrators.Workers()
+		// if err != nil {
+		// 	logger.Error(qi.ctx, "failed to get workers", "error", err)
+		// 	return false
+		// }
 		// qi.orchestrators.task
 		// // workersIDS := qi.orchestrators.ListWorkers()
-		// qi.orchestrators.RangeTasks(func(data *retrypool.TaskWrapper[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]], workerID int, status retrypool.TaskStatus) bool {
+		// qi.orchestrators.RangeTasks(func(data *retrypool.TaskWrapper[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]], workerID int, status retrypool.TaskStatus) bool {
 		// 	logger.Debug(qi.ctx, "task status", "workerID", workerID, "status", status, "task", data.Data().Request.workflowID)
 		// 	return true
 		// })
-		// qi.orchestrators.RangeWorkers(func(workerID int, worker retrypool.Worker[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]]) bool {
+		// qi.orchestrators.RangeWorkers(func(workerID int, worker retrypool.Worker[*retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]]) bool {
 		// 	logger.Debug(qi.ctx, "worker status", "workerID", workerID)
 		// 	return true
 		// })
-		logger.Debug(qi.ctx, "waiting for queue to finish", "queueSize", queueSize, "processingCount", processingCount, "deadTaskCount", deadTaskCount, "workers", len(workersIDS))
-		return queueSize > 0 || processingCount > 0
+		logger.Debug(qi.ctx, "waiting for queue to finish", "queueSize", queueSize, "processingCount", processingCount, "deadTaskCount", deadTaskCount)
+		return queueSize > 0 || processingCount > 0 || deadTaskCount > 0
 	}, time.Second)
 }
 
-func (qi *QueueInstance) Submit(workflowFunc interface{}, options *WorkflowOptions, opts *preparationOptions, args ...interface{}) (Future, *retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse], <-chan struct{}, error) {
+func (qi *QueueInstance) Submit(workflowFunc interface{}, options *WorkflowOptions, opts *preparationOptions, args ...interface{}) (Future, *retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID], error) {
 
 	workflowEntity, err := PrepareWorkflow(qi.registry, qi.database, workflowFunc, options, opts, args...)
 	if err != nil {
 		log.Printf("failed to prepare workflow: %v", err)
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	chnFuture := make(chan Future, 1)
 
-	queued := retrypool.NewQueuedNotification()
-
-	task := retrypool.NewRequestResponse[*WorkflowRequest, *WorkflowResponse](
+	task := retrypool.NewBlockingRequestResponse[*WorkflowRequest, *WorkflowResponse](
 		&WorkflowRequest{
 			workflowID:   workflowEntity.ID,
 			workflowFunc: workflowFunc,
@@ -258,44 +267,47 @@ func (qi *QueueInstance) Submit(workflowFunc interface{}, options *WorkflowOptio
 			chnFuture:    chnFuture,
 			queueName:    qi.name,
 		},
+		workflowEntity.RunID,
+		workflowEntity.ID,
 	)
 
-	if err := qi.orchestrators.Submit(task, retrypool.WithQueuedNotification[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]](queued)); err != nil {
+	if err := qi.orchestrators.
+		Submit(
+			task,
+		); err != nil {
 		fmt.Println("failed to submit task", err)
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
-	return <-chnFuture, task, queued.Done(), nil
+	return <-chnFuture, task, nil
 }
 
-func (qi *QueueInstance) SubmitResume(entityID WorkflowEntityID) (Future, *retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse], <-chan struct{}, error) {
+func (qi *QueueInstance) SubmitResume(entityID WorkflowEntityID) (Future, *retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID], error) {
 	// Get workflow entity with queue info
 	workflowEntity, err := qi.database.GetWorkflowEntity(entityID, WorkflowEntityWithQueue())
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to get workflow entity: %w", err)
+		return nil, nil, fmt.Errorf("failed to get workflow entity: %w", err)
 	}
 
 	// Verify the workflow is actually paused
 	var status EntityStatus
 	if err := qi.database.GetWorkflowEntityProperties(entityID, GetWorkflowEntityStatus(&status)); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to get workflow status: %w", err)
+		return nil, nil, fmt.Errorf("failed to get workflow status: %w", err)
 	}
 	if status != StatusPaused {
-		return nil, nil, nil, fmt.Errorf("workflow %d is not paused (current status: %s)", entityID, status)
+		return nil, nil, fmt.Errorf("workflow %d is not paused (current status: %s)", entityID, status)
 	}
 
 	// Get handler info
 	handler, ok := qi.registry.GetWorkflow(workflowEntity.HandlerName)
 	if !ok {
-		return nil, nil, nil, fmt.Errorf("workflow handler %s not found", workflowEntity.HandlerName)
+		return nil, nil, fmt.Errorf("workflow handler %s not found", workflowEntity.HandlerName)
 	}
 
 	chnFuture := make(chan Future, 1)
 
-	queued := retrypool.NewQueuedNotification()
-
 	// Create resume request
-	task := retrypool.NewRequestResponse[*WorkflowRequest, *WorkflowResponse](
+	task := retrypool.NewBlockingRequestResponse[*WorkflowRequest, *WorkflowResponse](
 		&WorkflowRequest{
 			workflowID:   workflowEntity.ID,
 			workflowFunc: handler.Handler, // Use the actual handler function
@@ -304,14 +316,16 @@ func (qi *QueueInstance) SubmitResume(entityID WorkflowEntityID) (Future, *retry
 			resume:       true,  // Mark this as a resume
 			chnFuture:    chnFuture,
 		},
+		workflowEntity.RunID,
+		workflowEntity.ID,
 	)
 
-	if err := qi.orchestrators.Submit(task, retrypool.WithQueuedNotification[*retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]](queued)); err != nil {
+	if err := qi.orchestrators.Submit(task); err != nil {
 		fmt.Println("failed to submit task", err)
-		return nil, nil, nil, fmt.Errorf("failed to submit resume task: %w", err)
+		return nil, nil, fmt.Errorf("failed to submit resume task: %w", err)
 	}
 
-	return <-chnFuture, task, queued.Done(), nil
+	return <-chnFuture, task, nil
 }
 
 type onStartFunc func(context.Context)
@@ -379,7 +393,7 @@ func (w *QueueWorker) OnRemove(ctx context.Context) {
 	// log.Printf("Queue worker started for queue %s", w.queueInstance.name)
 }
 
-func (w *QueueWorker) Run(ctx context.Context, task *retrypool.RequestResponse[*WorkflowRequest, *WorkflowResponse]) error {
+func (w *QueueWorker) Run(ctx context.Context, task *retrypool.BlockingRequestResponse[*WorkflowRequest, *WorkflowResponse, RunID, WorkflowEntityID]) error {
 
 	// Mark entity as processing
 	w.queueInstance.workerMu.Lock()
@@ -478,7 +492,7 @@ type TempoliteOption func(*Tempolite) error
 
 // createCrossWorkflowHandler creates the handler function for cross-queue workflow communication
 func (t *Tempolite) createCrossWorkflowHandler() crossQueueWorkflowHandler {
-	return func(queueName string, workflowID WorkflowEntityID, workflowFunc interface{}, options *WorkflowOptions, args ...interface{}) Future {
+	return func(queueName string, workflowID WorkflowEntityID, runID RunID, workflowFunc interface{}, options *WorkflowOptions, args ...interface{}) Future {
 		t.mu.RLock()
 		queue, ok := t.queueInstances[queueName]
 		t.mu.RUnlock()
@@ -491,15 +505,19 @@ func (t *Tempolite) createCrossWorkflowHandler() crossQueueWorkflowHandler {
 		chnFuture := make(chan Future, 1)
 
 		if err := queue.orchestrators.Submit(
-			retrypool.NewRequestResponse[*WorkflowRequest, *WorkflowResponse](&WorkflowRequest{
-				workflowFunc: workflowFunc,
-				options:      options,
-				workflowID:   workflowID,
-				args:         args,
-				chnFuture:    chnFuture,
-				queueName:    queueName,
-				continued:    false,
-			})); err != nil {
+			retrypool.NewBlockingRequestResponse[*WorkflowRequest, *WorkflowResponse](
+				&WorkflowRequest{
+					workflowFunc: workflowFunc,
+					options:      options,
+					workflowID:   workflowID,
+					args:         args,
+					chnFuture:    chnFuture,
+					queueName:    queueName,
+					continued:    false,
+				},
+				runID,
+				workflowID,
+			)); err != nil {
 			fmt.Println("failed to submit task", err)
 			futureErr := NewRuntimeFuture()
 			futureErr.SetError(err)
@@ -511,7 +529,7 @@ func (t *Tempolite) createCrossWorkflowHandler() crossQueueWorkflowHandler {
 }
 
 func (t *Tempolite) createContinueAsNewHandler() crossQueueContinueAsNewHandler {
-	return func(queueName string, workflowID WorkflowEntityID, workflowFunc interface{}, options *WorkflowOptions, args ...interface{}) Future {
+	return func(queueName string, workflowID WorkflowEntityID, runID RunID, workflowFunc interface{}, options *WorkflowOptions, args ...interface{}) Future {
 		t.mu.Lock()
 		queue, ok := t.queueInstances[queueName]
 		t.mu.Unlock()
@@ -525,15 +543,19 @@ func (t *Tempolite) createContinueAsNewHandler() crossQueueContinueAsNewHandler 
 
 		// Handle version inheritance through ContinueAsNew
 		if err := queue.orchestrators.Submit(
-			retrypool.NewRequestResponse[*WorkflowRequest, *WorkflowResponse](&WorkflowRequest{
-				workflowID:   workflowID,
-				workflowFunc: workflowFunc,
-				options:      options,
-				args:         args,
-				chnFuture:    chnFuture,
-				queueName:    queueName,
-				continued:    true, // Mark this as a continuation
-			})); err != nil {
+			retrypool.NewBlockingRequestResponse[*WorkflowRequest, *WorkflowResponse](
+				&WorkflowRequest{
+					workflowID:   workflowID,
+					workflowFunc: workflowFunc,
+					options:      options,
+					args:         args,
+					chnFuture:    chnFuture,
+					queueName:    queueName,
+					continued:    true, // Mark this as a continuation
+				},
+				runID,
+				workflowID,
+			)); err != nil {
 			fmt.Println("failed to submit task", err)
 			futureErr := NewRuntimeFuture()
 			futureErr.SetError(err)
@@ -731,13 +753,13 @@ func (t *Tempolite) Execute(queueName string, workflowFunc interface{}, options 
 		return nil, fmt.Errorf("queue %s not found", queueName)
 	}
 
-	future, _, queued, err := queue.Submit(workflowFunc, options, nil, args...)
+	future, _, err := queue.Submit(workflowFunc, options, nil, args...)
 	if err != nil {
 		fmt.Println("failed to submit task", err)
 		return nil, fmt.Errorf("failed to submit workflow to queue %s: %w", queueName, err)
 	}
 
-	<-queued
+	// <-queued
 
 	if err := future.WaitForIDs(t.ctx); err != nil {
 		return nil, fmt.Errorf("failed to wait for workflow IDs: %w", err)
@@ -789,87 +811,87 @@ func (t *Tempolite) Resume(id WorkflowEntityID) (Future, error) {
 	}
 
 	// Submit resume request to queue
-	future, _, queued, err := queue.SubmitResume(id)
+	future, _, err := queue.SubmitResume(id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resume workflow: %w", err)
 	}
 
-	<-queued
+	// <-queued
 
 	return future, nil
 }
 
-func (t *Tempolite) ScaleQueue(queueName string, targetCount int) error {
-	t.mu.RLock()
-	instance, exists := t.queueInstances[queueName]
-	t.mu.RUnlock()
+// func (t *Tempolite) ScaleQueue(queueName string, targetCount int) error {
+// 	t.mu.RLock()
+// 	instance, exists := t.queueInstances[queueName]
+// 	t.mu.RUnlock()
 
-	if !exists {
-		return fmt.Errorf("queue %s not found", queueName)
-	}
+// 	if !exists {
+// 		return fmt.Errorf("queue %s not found", queueName)
+// 	}
 
-	currentCount := atomic.LoadInt32(&instance.count)
-	delta := int32(targetCount) - currentCount
+// 	currentCount := atomic.LoadInt32(&instance.count)
+// 	delta := int32(targetCount) - currentCount
 
-	logger.Info(t.ctx, "Scaling queue", "queueName", queueName, "current", currentCount, "target", targetCount, "delta", delta)
+// 	logger.Info(t.ctx, "Scaling queue", "queueName", queueName, "current", currentCount, "target", targetCount, "delta", delta)
 
-	if delta > 0 {
-		// Add workers
-		for i := int32(0); i < delta; i++ {
-			worker := NewQueueWorker(instance)
-			instance.orchestrators.Add(worker, instance.orchestrators.NewTaskQueue(retrypool.TaskQueueTypeSlice))
-			atomic.AddInt32(&instance.count, 1)
-			logger.Info(t.ctx, "Added worker to queue", "queueName", queueName)
-		}
-	} else if delta < 0 {
-		// Remove workers
-		absCount := -delta
-		if absCount > currentCount {
-			return fmt.Errorf("cannot remove %d workers, only %d available", absCount, currentCount)
-		}
+// 	if delta > 0 {
+// 		// Add workers
+// 		for i := int32(0); i < delta; i++ {
+// 			worker := NewQueueWorker(instance)
+// 			instance.orchestrators.Add(worker, instance.orchestrators.NewTaskQueue(retrypool.TaskQueueTypeSlice))
+// 			atomic.AddInt32(&instance.count, 1)
+// 			logger.Info(t.ctx, "Added worker to queue", "queueName", queueName)
+// 		}
+// 	} else if delta < 0 {
+// 		// Remove workers
+// 		absCount := -delta
+// 		if absCount > currentCount {
+// 			return fmt.Errorf("cannot remove %d workers, only %d available", absCount, currentCount)
+// 		}
 
-		instance.workerMu.RLock()
-		workers, err := instance.orchestrators.Workers()
-		instance.workerMu.RUnlock()
-		if err != nil {
-			return fmt.Errorf("failed to get workers: %w", err)
-		}
+// 		instance.workerMu.RLock()
+// 		workers, err := instance.orchestrators.Workers()
+// 		instance.workerMu.RUnlock()
+// 		if err != nil {
+// 			return fmt.Errorf("failed to get workers: %w", err)
+// 		}
 
-		for i := int32(0); i < absCount && i < int32(len(workers)); i++ {
-			logger.Info(t.ctx, "Removing worker from queue", "queueName", queueName)
-			worker := workers[len(workers)-1-int(i)]
-			if err := instance.orchestrators.Remove(worker); err != nil {
-				return fmt.Errorf("failed to remove worker: %w", err)
-			}
+// 		for i := int32(0); i < absCount && i < int32(len(workers)); i++ {
+// 			logger.Info(t.ctx, "Removing worker from queue", "queueName", queueName)
+// 			worker := workers[len(workers)-1-int(i)]
+// 			if err := instance.orchestrators.Remove(worker); err != nil {
+// 				return fmt.Errorf("failed to remove worker: %w", err)
+// 			}
 
-			// Clean up worker references
-			instance.workerMu.Lock()
-			delete(instance.workers, worker)
-			instance.workerMu.Unlock()
+// 			// Clean up worker references
+// 			instance.workerMu.Lock()
+// 			delete(instance.workers, worker)
+// 			instance.workerMu.Unlock()
 
-			atomic.AddInt32(&instance.count, -1)
-			logger.Info(t.ctx, "Removed worker from queue", "queueName", queueName)
-		}
-	}
+// 			atomic.AddInt32(&instance.count, -1)
+// 			logger.Info(t.ctx, "Removed worker from queue", "queueName", queueName)
+// 		}
+// 	}
 
-	workers, err := instance.orchestrators.Workers()
-	if err != nil {
-		return fmt.Errorf("failed to get workers: %w", err)
-	}
+// 	workers, err := instance.orchestrators.Workers()
+// 	if err != nil {
+// 		return fmt.Errorf("failed to get workers: %w", err)
+// 	}
 
-	if len(workers) == 0 {
-		logger.Debug(t.ctx, "no workers in queue", "queueName", queueName)
-	} else {
-		logger.Debug(t.ctx, "workers in queue", "queueName", queueName, "count", len(workers))
-	}
+// 	if len(workers) == 0 {
+// 		logger.Debug(t.ctx, "no workers in queue", "queueName", queueName)
+// 	} else {
+// 		logger.Debug(t.ctx, "workers in queue", "queueName", queueName, "count", len(workers))
+// 	}
 
-	instance.orchestrators.RangeWorkerQueues(func(workerID int, queueSize int64) bool {
-		logger.Debug(t.ctx, "worker queue size", "workerID", workerID, "queueSize", queueSize)
-		return true
-	})
+// 	instance.orchestrators.RangeWorkerQueues(func(workerID int, queueSize int64) bool {
+// 		logger.Debug(t.ctx, "worker queue size", "workerID", workerID, "queueSize", queueSize)
+// 		return true
+// 	})
 
-	return nil
-}
+// 	return nil
+// }
 
 func (t *Tempolite) Close() error {
 	t.cancel()

--- a/tempolite_test.go
+++ b/tempolite_test.go
@@ -101,12 +101,12 @@ func TestQueueCrossBasic(t *testing.T) {
 		return nil
 	}
 
-	future, _, err := defaultQ.Submit(wrkfl, nil, nil)
+	future, _, q, err := defaultQ.Submit(wrkfl, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// <-q
+	<-q.Done()
 
 	if err := future.Get(); err != nil {
 		t.Fatal(err)

--- a/tempolite_test.go
+++ b/tempolite_test.go
@@ -21,7 +21,7 @@ func TestQueueCrossBasic(t *testing.T) {
 	var defaultQ *QueueInstance
 	var secondQ *QueueInstance
 
-	var onCross crossQueueWorkflowHandler = func(queueName string, workflowID WorkflowEntityID, workflowFunc interface{}, options *WorkflowOptions, args ...interface{}) Future {
+	var onCross crossQueueWorkflowHandler = func(queueName string, workflowID WorkflowEntityID, runID RunID, workflowFunc interface{}, options *WorkflowOptions, args ...interface{}) Future {
 
 		queue, err := db.GetQueueByName(queueName)
 		if err != nil {
@@ -34,7 +34,7 @@ func TestQueueCrossBasic(t *testing.T) {
 
 		if queue.Name == "default" {
 			if err := defaultQ.orchestrators.Submit(
-				retrypool.NewRequestResponse[*WorkflowRequest, *WorkflowResponse](&WorkflowRequest{
+				retrypool.NewBlockingRequestResponse[*WorkflowRequest, *WorkflowResponse](&WorkflowRequest{
 					workflowFunc: workflowFunc,
 					options:      options,
 					workflowID:   workflowID,
@@ -42,14 +42,14 @@ func TestQueueCrossBasic(t *testing.T) {
 					chnFuture:    chnFuture,
 					queueName:    queueName,
 					continued:    true,
-				})); err != nil {
+				}, runID, workflowID)); err != nil {
 				future := NewRuntimeFuture()
 				future.SetError(err)
 				return future
 			}
 		} else if queue.Name == "second" {
 			if err := secondQ.orchestrators.Submit(
-				retrypool.NewRequestResponse[*WorkflowRequest, *WorkflowResponse](&WorkflowRequest{
+				retrypool.NewBlockingRequestResponse[*WorkflowRequest, *WorkflowResponse](&WorkflowRequest{
 					workflowFunc: workflowFunc,
 					options:      options,
 					workflowID:   workflowID,
@@ -57,7 +57,7 @@ func TestQueueCrossBasic(t *testing.T) {
 					chnFuture:    chnFuture,
 					queueName:    queueName,
 					continued:    true,
-				})); err != nil {
+				}, runID, workflowID)); err != nil {
 				future := NewRuntimeFuture()
 				future.SetError(err)
 				return future
@@ -101,12 +101,12 @@ func TestQueueCrossBasic(t *testing.T) {
 		return nil
 	}
 
-	future, _, q, err := defaultQ.Submit(wrkfl, nil, nil)
+	future, _, err := defaultQ.Submit(wrkfl, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	<-q
+	// <-q
 
 	if err := future.Get(); err != nil {
 		t.Fatal(err)
@@ -181,10 +181,13 @@ func TestTempoliteBasicCross(t *testing.T) {
 	}
 }
 
+// We're stuck there
 func TestTempoliteBasicSubWorkflow(t *testing.T) {
 
 	ctx := context.Background()
 	db := NewMemoryDatabase()
+
+	defer db.SaveAsJSON("./json/tempolite_subworkflow.json")
 
 	tp, err := New(
 		ctx,
@@ -198,7 +201,9 @@ func TestTempoliteBasicSubWorkflow(t *testing.T) {
 
 	var subWork func(ctx WorkflowContext) error
 
+	// To make the continue as new feature working or others, we need the retrypool round-robin
 	subWork = func(ctx WorkflowContext) error {
+		db.SaveAsJSON("./json/tempolite_subworkflow.json")
 		fmt.Println("Hello, second world!")
 		<-time.After(1 * time.Second)
 		if counter.Load() < 5 {
@@ -264,7 +269,8 @@ func TestTempoliteBasicSecondQueueSubWorkflow(t *testing.T) {
 
 	subWork = func(ctx WorkflowContext) error {
 		fmt.Println("Hello, second world!")
-		<-time.After(1 * time.Second)
+		// Adding a delay makes it not working?1
+		// <-time.After(1 * time.Second)
 		if counter.Load() < 5 {
 			counter.Store(counter.Load() + 1)
 			fmt.Println("second ", counter.Load())

--- a/tests/orchestrator/cross-queue/cross_activities_test.go
+++ b/tests/orchestrator/cross-queue/cross_activities_test.go
@@ -42,6 +42,7 @@ func TestWorkflowCrossWorkflowsActivitiesQueue(t *testing.T) {
 			func(
 				queueName string,
 				workflowID tempolite.WorkflowEntityID,
+				runID tempolite.RunID,
 				workflowFunc interface{},
 				options *tempolite.WorkflowOptions,
 				args ...interface{},

--- a/tests/orchestrator/cross-queue/cross_workflows_test.go
+++ b/tests/orchestrator/cross-queue/cross_workflows_test.go
@@ -48,6 +48,7 @@ func TestWorkflowCrossWorkflowsQueue(t *testing.T) {
 			func(
 				queueName string,
 				workflowID tempolite.WorkflowEntityID,
+				runID tempolite.RunID,
 				workflowFunc interface{},
 				options *tempolite.WorkflowOptions,
 				args ...interface{},
@@ -205,6 +206,7 @@ func TestWorkflowCrossWorkflowsQueueFailure(t *testing.T) {
 			func(
 				queueName string,
 				workflowID tempolite.WorkflowEntityID,
+				runID tempolite.RunID,
 				workflowFunc interface{},
 				options *tempolite.WorkflowOptions,
 				args ...interface{},
@@ -365,6 +367,7 @@ func TestWorkflowCrossWorkflowsQueuePanic(t *testing.T) {
 			func(
 				queueName string,
 				workflowID tempolite.WorkflowEntityID,
+				runID tempolite.RunID,
 				workflowFunc interface{},
 				options *tempolite.WorkflowOptions,
 				args ...interface{},

--- a/tests/orchestrator/cross-queue/pause-resume/cross_workflows_pause-resume_test.go
+++ b/tests/orchestrator/cross-queue/pause-resume/cross_workflows_pause-resume_test.go
@@ -30,8 +30,13 @@ func TestWorkflowCrossQueuePauseResume(t *testing.T) {
 	// Create default orchestrator with cross-queue handling
 	orchestratorDefault := tempolite.NewOrchestrator(
 		ctx, database, registry,
-		tempolite.WithCrossWorkflow(func(queueName string, workflowID tempolite.WorkflowEntityID,
-			workflowFunc interface{}, options *tempolite.WorkflowOptions, args ...interface{}) tempolite.Future {
+		tempolite.WithCrossWorkflow(func(
+			queueName string,
+			workflowID tempolite.WorkflowEntityID,
+			runID tempolite.RunID,
+			workflowFunc interface{},
+			options *tempolite.WorkflowOptions,
+			args ...interface{}) tempolite.Future {
 
 			if queueName == "side" {
 				future, err := orchestratorSide.ExecuteWithEntity(workflowID)

--- a/tests/tempolite/scale_test.go
+++ b/tests/tempolite/scale_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,21 +25,21 @@ func TestTempoliteScale(t *testing.T) {
 	}
 
 	fmt.Println("Scale up")
-	if err := tp.ScaleQueue(tempolite.DefaultQueue, 2); err != nil {
+	if err := tp.Scale(tempolite.DefaultQueue, 2); err != nil {
 		t.Fatal(err)
 	}
 
 	<-time.After(time.Second)
 
 	fmt.Println("Scale up")
-	if err := tp.ScaleQueue(tempolite.DefaultQueue, 4); err != nil {
+	if err := tp.Scale(tempolite.DefaultQueue, 4); err != nil {
 		t.Fatal(err)
 	}
 
 	<-time.After(time.Second)
 
 	fmt.Println("Scale down")
-	if err := tp.ScaleQueue(tempolite.DefaultQueue, 0); err != nil {
+	if err := tp.Scale(tempolite.DefaultQueue, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -49,63 +50,154 @@ func TestTempoliteScale(t *testing.T) {
 }
 
 func TestTempoliteScaleConcurrentWorkflows(t *testing.T) {
-
-	database := tempolite.NewMemoryDatabase()
-	defer database.SaveAsJSON("./jsons/tempolite_workflows_execute.json")
 	ctx := context.Background()
 
-	tp, err := tempolite.New(
-		ctx,
-		database,
-	)
-	if err != nil {
-		t.Fatal(err)
+	var workflowCounts []struct {
+		scale int
+		count int32
 	}
 
+	var executionsPerSecond []struct {
+		scale  int
+		second int
+		count  int32
+	}
+
+	var startedWorkflows int32
+	var globalStartedWorkflows int32
+
 	workflowFunc := func(ctx tempolite.WorkflowContext) (int, error) {
+		atomic.AddInt32(&startedWorkflows, 1)
+		atomic.AddInt32(&globalStartedWorkflows, 1)
 		return 1, nil
 	}
 
-	go func() {
-		for i := 0; i < 100; i++ {
-			if _, err := tp.ExecuteDefault(workflowFunc, nil); err != nil {
+	for scale := 1; scale <= 5; scale++ {
+		database := tempolite.NewMemoryDatabase()
+		tp, err := tempolite.New(
+			ctx,
+			database,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fmt.Printf("Scale %d\n", scale)
+		if err := tp.Scale(tempolite.DefaultQueue, scale); err != nil {
+			t.Fatal(err)
+		}
+
+		// Schedule 7500 workflows
+		go func() {
+			for i := 0; i < 7500; i++ {
+				if _, err := tp.ExecuteDefault(workflowFunc, nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}()
+
+		go func() {
+			for i := 0; i < 7500; i++ {
+				if _, err := tp.ExecuteDefault(workflowFunc, nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}()
+
+		go func() {
+			for i := 0; i < 7500; i++ {
+				if _, err := tp.ExecuteDefault(workflowFunc, nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}()
+
+		time.Sleep(time.Second)
+
+		start := time.Now()
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		done := make(chan bool)
+		go func(s int) {
+			second := 0
+			for {
+				select {
+				case <-ticker.C:
+					c := atomic.SwapInt32(&startedWorkflows, 0)
+					executionsPerSecond = append(executionsPerSecond, struct {
+						scale  int
+						second int
+						count  int32
+					}{s, second, c})
+					second++
+				case <-done:
+					return
+				}
+			}
+		}(scale)
+
+		for {
+			queueCount, err := tp.CountQueue(tempolite.DefaultQueue, tempolite.StatusCompleted)
+			if err != nil {
 				t.Fatal(err)
 			}
+			if queueCount == 22500 {
+				break
+			}
+			time.Sleep(time.Second)
+			fmt.Println("Queue count:", queueCount)
 		}
-	}()
+		duration := time.Since(start).Seconds()
 
-	fmt.Println("Scale up")
-	if err := tp.ScaleQueue(tempolite.DefaultQueue, 2); err != nil {
-		t.Fatal(err)
+		// Use globalStartedWorkflows to track how many total were actually started
+		c := atomic.LoadInt32(&globalStartedWorkflows)
+		workflowCounts = append(workflowCounts, struct {
+			scale int
+			count int32
+		}{scale, c})
+		atomic.StoreInt32(&globalStartedWorkflows, 0)
+
+		done <- true
+
+		fmt.Printf("Scale %d: %d workflows started in %.2f seconds\n", scale, c, duration)
+
+		fmt.Println("Close")
+		tp.Close()
 	}
 
-	<-time.After(time.Second)
-
-	fmt.Println("Scale up")
-	if err := tp.ScaleQueue(tempolite.DefaultQueue, 4); err != nil {
-		t.Fatal(err)
+	fmt.Println("Workflow counts per scale change:")
+	for _, wc := range workflowCounts {
+		fmt.Printf("Scale %d: %d workflows started\n", wc.scale, wc.count)
 	}
 
-	<-time.After(time.Second)
-
-	fmt.Println("Scale down")
-	if err := tp.ScaleQueue(tempolite.DefaultQueue, 1); err != nil {
-		t.Fatal(err)
+	fmt.Println("Executions per second (chronological):")
+	for _, eps := range executionsPerSecond {
+		fmt.Printf("Scale %d - Second %d: %d executions\n", eps.scale, eps.second, eps.count)
 	}
 
-	<-time.After(time.Second * 5)
-
-	fmt.Println("Scale Up")
-	if err := tp.ScaleQueue(tempolite.DefaultQueue, 2); err != nil {
-		t.Fatal(err)
+	// Example of computing an average per second across all logs
+	fmt.Println("Averages per scale:")
+	currentScale := 1
+	var sum, secs int32
+	for _, eps := range executionsPerSecond {
+		if eps.scale != currentScale {
+			if secs > 0 {
+				fmt.Printf("Scale %d average: %.2f executions/sec\n",
+					currentScale,
+					float64(sum)/float64(secs),
+				)
+			}
+			currentScale = eps.scale
+			sum, secs = 0, 0
+		}
+		sum += eps.count
+		secs++
 	}
-
-	<-time.After(time.Second)
-
-	if err := tp.Wait(); err != nil {
-		t.Fatal(err)
+	if secs > 0 {
+		fmt.Printf("Scale %d average: %.2f executions/sec\n",
+			currentScale,
+			float64(sum)/float64(secs),
+		)
 	}
-
-	tp.Close()
-
 }


### PR DESCRIPTION
After the update of `retrypool`, we have BlockingPool which manage the dependencies of the different orchestrator instances related within a pool of workers. It is now easier to scale up or down too.